### PR TITLE
docs: Fix wrong cli command in Readme for creating a node app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Boilerplate to create an embedded Shopify app made with Node, [Next.js](https://
 Using the [Shopify-App-CLI](https://github.com/Shopify/shopify-app-cli) run:
 
 ```sh
-~/ $ shopify create project APP_NAME
+~/ $ shopify node create project APP_NAME
 ```
 
 Or, fork and clone repo


### PR DESCRIPTION
The correct command to create a shopify node app is
`shopify node create <project name>`
